### PR TITLE
allow bare column names

### DIFF
--- a/src/header/implementation.lisp
+++ b/src/header/implementation.lisp
@@ -66,7 +66,9 @@
          (signature-class (read-column-signature-class result))
          (column-signatures (map 'vector
                                  (lambda (c)
-                                   (apply #'make signature-class c))
+                                   (apply #'make signature-class
+                                          (cond ((listp c) c)
+                                                ((atom c) `(:name ,c)))))
                                  columns))
          (names (iterate
                   (with result = (make-hash-table


### PR DESCRIPTION
 * If column specification is an atom instead of a list in
 make-header (also called from make-table), treat that as the column
 name as if it were (:name foo).