### PR TITLE
Jupyter Support - Output Table As HTML

### DIFF
--- a/src/table/implementation.lisp
+++ b/src/table/implementation.lisp
@@ -640,7 +640,7 @@
         (funcall (find-symbol "HTML" :JUPYTER) (get-output-stream-string string-stream) :display t))
 
       (print-unreadable-object (object stream)
-                               (show :text object :output stream)))
+        (show :text object :output stream)))
     (call-next-method))
   object)
 

--- a/src/table/implementation.lisp
+++ b/src/table/implementation.lisp
@@ -632,16 +632,13 @@
           (string= "IOPUB-STREAM" (symbol-name (type-of *standard-output*)))))
 
 (defmethod print-object ((object fundamental-table) stream)
-  (if *print-pretty*
-    (if (run-in-jupyter-p)
-      ; Print 10 rows for jupyter output
-      (let ((string-stream (make-string-output-stream)))
-        (show :html object :output string-stream :end 10)
-        (funcall (find-symbol "HTML" :JUPYTER) (get-output-stream-string string-stream) :display t))
+  (cond ((run-in-jupyter-p)
+         (funcall (find-symbol "HTML" :JUPYTER)
+                  (with-output-to-string (string-stream) (vellum:show :html object  :output string-stream :end 10))
+                  :display t))
+        (*print-pretty* (print-unreadable-object (object stream) (show :text object :output stream))))
 
-      (print-unreadable-object (object stream)
-        (show :text object :output stream)))
-    (call-next-method))
+  (call-next-method)
   object)
 
 

--- a/src/table/implementation.lisp
+++ b/src/table/implementation.lisp
@@ -634,11 +634,10 @@
 (defmethod print-object ((object fundamental-table) stream)
   (cond ((run-in-jupyter-p)
          (funcall (find-symbol "HTML" :JUPYTER)
-                  (with-output-to-string (string-stream) (vellum:show :html object  :output string-stream :end 10))
+                  (with-output-to-string (string-stream) (show :html object  :output string-stream :end 10))
                   :display t))
-        (*print-pretty* (print-unreadable-object (object stream) (show :text object :output stream))))
-
-  (call-next-method)
+        (*print-pretty* (print-unreadable-object (object stream) (show :text object :output stream)))
+        (t (call-next-method)))
   object)
 
 


### PR DESCRIPTION
I add a new feature: Jupyter Support - Output Table As HTML. 

![image](https://github.com/sirherrbatka/vellum/assets/8326287/66134649-a34a-4dac-a1c9-ee4b67b886b3)

This will allow vellum display table as html in jupyter automatically.

Considering that `common-lisp-jupyter` has no significance for vellum, I just simply check if the `jupyter` package is loaded. And call the `html` function by `(funcall (find-symbol "HTML" :JUPYTER)  ...)`

Hope you have a better idea for it.

BTW: I'm not good at writing cl code, please review it carefully. 